### PR TITLE
Fix $IMAGE variable.

### DIFF
--- a/pre-release
+++ b/pre-release
@@ -1,5 +1,5 @@
 #!/bin/bash
-APP="$1"; IMAGE="$2"
+APP="$1"; IMAGE="app/$APP"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 set -e
 echo "-----> Injecting Node ..."


### PR DESCRIPTION
In the current version of dokku the $IMAGE variable is no longer passed in to pluginhooks, causing this script to break. The fix is easy, just need to change it from being `IMAGE="$2"` to `IMAGE="app/$APP"`.

More details about the fix, and the commit that changed this, here:
https://github.com/progrium/dokku/issues/313#issuecomment-31210408
